### PR TITLE
feat(map): reuse TreemapTooltip in ChileMap for hover details

### DIFF
--- a/app/components/map/ChileMap.tsx
+++ b/app/components/map/ChileMap.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import * as d3 from 'd3';
+import { TreemapTooltip } from './TreemapTooltip';
 import type {
   MapViewState,
   EnrichedRegionData,
@@ -9,6 +10,7 @@ import type {
   ColorScale,
 } from '@/types/map';
 import { useViewportSize } from './hooks/useViewportSize';
+import { decimalToRoman } from '@/lib/number-to-roman';
 
 interface ChileMapProps {
   regionsData: EnrichedRegionData[];
@@ -33,6 +35,25 @@ export function ChileMap({
   const containerRef = useRef<HTMLDivElement>(null);
   const [dimensions, setDimensions] = useState({ width: 600, height: 600 });
   
+  // Refs para evitar re-renders innecesarios
+  const hoverDataRef = useRef<{
+    name: string;
+    code: string;
+    x: number;
+    y: number;
+  } | null>(null);
+
+  // State para tooltip
+  const [tooltipData, setTooltipData] = useState<{
+    name: string;
+    secondary?: string;
+    x: number;
+    y: number;
+  } | null>(null);
+  
+  // RequestAnimationFrame ref
+  const rafRef = useRef<number | null>(null);
+
   // Use custom hooks
   const viewportSize = useViewportSize();
 
@@ -54,7 +75,7 @@ export function ChileMap({
   // Setup D3 projection centered on Chile or selected region
   const projection = useCallback(() => {
     const baseProjection = d3.geoMercator();
-    
+
     if (viewState.level === 'region' && viewState.selectedRegion && municipalitiesData.length > 0) {
       // Use D3's fitExtent to automatically calculate correct projection parameters
       const padding = 20;
@@ -65,11 +86,11 @@ export function ChileMap({
           viewState.selectedRegion
         );
     }
-    
+
     // Default: center on Chile with breakpoint-specific values
     let scale: number;
     let rotate: [number, number, number];
-    
+
     if (viewportSize === 'mobile') {
       scale = 800;
       rotate = [70.5, 37, 0];
@@ -80,7 +101,7 @@ export function ChileMap({
       scale = 800;
       rotate = [70.5, 37, 0];
     }
-    
+
     return baseProjection
       .rotate(rotate)
       .center([0, 0])
@@ -100,7 +121,7 @@ export function ChileMap({
       if (overpricing === null || overpricing === undefined) {
         return '#E5E7EB'; // Gray for no data
       }
-      
+
       // Find the appropriate tier based on threshold
       for (let i = colorScale.breakpoints.length - 1; i >= 0; i--) {
         if (overpricing >= colorScale.breakpoints[i].threshold) {
@@ -108,7 +129,7 @@ export function ChileMap({
           return colorScale.breakpoints[i].texture || colorScale.breakpoints[i].color;
         }
       }
-      
+
       // Default to first tier if below all thresholds
       return colorScale.breakpoints[0]?.texture || colorScale.breakpoints[0]?.color || '#E5E7EB';
     },
@@ -139,6 +160,58 @@ export function ChileMap({
   const styles = getComputedStyle(document.documentElement);
   const colorStroke = styles.getPropertyValue('--color-secondary').trim();
 
+  // Activar tooltip con mouseenter
+  const handleHoverIn = useCallback(
+    (name: string, code: string, e: React.MouseEvent) => {
+      const data = {
+        name,
+        secondary: code ? decimalToRoman(parseInt(code)) : undefined,
+        x: e.clientX,
+        y: e.clientY,
+      };
+      hoverDataRef.current = { name, code, x: e.clientX, y: e.clientY };
+      setTooltipData(data);
+    },
+    [],
+  );
+
+  // Actualizar posición con mousemove optimizado usando requestAnimationFrame
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      if (!hoverDataRef.current) return;
+
+      // Cancelar raf anterior
+      if (rafRef.current) {
+        cancelAnimationFrame(rafRef.current);
+      }
+
+      // Usar requestAnimationFrame para evitar muchos re-renders
+      rafRef.current = requestAnimationFrame(() => {
+        if (hoverDataRef.current) {
+          hoverDataRef.current.x = e.clientX;
+          hoverDataRef.current.y = e.clientY;
+          setTooltipData((current) =>
+            current ? { ...current, x: e.clientX, y: e.clientY } : current
+          );
+        }
+      });
+    },
+    [],
+  );
+
+  // Desactivar tooltip con mouseleave
+  const handleHoverOut = useCallback(() => {
+    if (rafRef.current) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+    
+    hoverDataRef.current = null;
+    setTooltipData(null);
+  }, []);
+
+  
+
   return (
     <div ref={containerRef} className="relative">
       <svg
@@ -154,29 +227,34 @@ export function ChileMap({
               const regionName = region.feature.properties.Region || `Región ${regionCode}`;
               const overpricing = region.averageOverpricing;
               const overpricingText = overpricing !== null && overpricing !== undefined
-                ? `sobreprecio promedio ${(overpricing * 100).toFixed(1)}%`
+                  ? `sobreprecio promedio ${(overpricing * 100).toFixed(1)}%`
                 : 'sin datos';
 
               return (
-                <path
-                  key={regionCode}
+                  <path
+                    key={regionCode}
                   d={pathGenerator(region.feature) || ''}
-                  fill={getFill(overpricing)}
-                  stroke={colorStroke}
-                  strokeWidth={0.6}
-                  className="cursor-pointer transition-all duration-200 hover:opacity-80 hover:stroke-[1.2px] focus:outline-none focus:stroke-[2px] focus:opacity-80"
+                    fill={getFill(overpricing)}
+                    stroke={colorStroke}
+                    strokeWidth={0.6}
+                    className="cursor-pointer transition-all duration-200 hover:opacity-80 hover:stroke-[1.2px] focus:outline-none focus:stroke-[2px] focus:opacity-80"
                   style={{ outline: 'none' }}
-                  tabIndex={0}
-                  role="button"
-                  aria-label={`${regionName}, ${overpricingText}. Presiona Enter para ver municipalidades.`}
-                  onClick={() => handleRegionClick(regionCode)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault();
-                      handleRegionClick(regionCode);
+                    tabIndex={0}
+                    role="button"
+                    aria-label={`${regionName}, ${overpricingText}. Presiona Enter para ver municipalidades.`}
+                    onClick={() => handleRegionClick(regionCode)}
+                    onMouseEnter={(e: React.MouseEvent<SVGPathElement>) =>
+                      handleHoverIn(regionName, regionCode, e)
                     }
-                  }}
-                />
+                    onMouseMove={handleMouseMove}
+                    onMouseLeave={handleHoverOut}
+                    onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        handleRegionClick(regionCode);
+                      }
+                    }}
+                  />
               );
             })}
 
@@ -187,7 +265,7 @@ export function ChileMap({
               const municipalityName = municipality.feature.properties.Comuna || `Comuna ${municipalityCode}`;
               const overpricing = municipality.data?.porcentaje_sobreprecio;
               const overpricingText = overpricing !== null && overpricing !== undefined
-                ? `sobreprecio ${(overpricing * 100).toFixed(1)}%`
+                  ? `sobreprecio ${(overpricing * 100).toFixed(1)}%`
                 : 'sin datos';
 
               return (
@@ -203,6 +281,11 @@ export function ChileMap({
                   role="button"
                   aria-label={`${municipalityName}, ${overpricingText}. Presiona Enter para ver detalles.`}
                   onClick={() => handleMunicipalityClick(municipalityCode)}
+                  onMouseEnter={(e: React.MouseEvent<SVGPathElement>) =>
+                    handleHoverIn(municipalityName, "", e)
+                  }
+                  onMouseMove={handleMouseMove}
+                  onMouseLeave={handleHoverOut}
                   onKeyDown={(e) => {
                     if (e.key === 'Enter' || e.key === ' ') {
                       e.preventDefault();
@@ -227,6 +310,8 @@ export function ChileMap({
         </g>
       </svg>
 
+      {/* Tooltip */}
+      <TreemapTooltip data={tooltipData} />
     </div>
   );
 }

--- a/app/components/map/TreemapTooltip.tsx
+++ b/app/components/map/TreemapTooltip.tsx
@@ -3,8 +3,9 @@ import { useFormatters } from '@/app/lib/hooks/useFormatters';
 interface TreemapTooltipProps {
   data: {
     name: string;
-    value: number;
-    overpricingRate: number;
+    value?: number;
+    secondary?: string;
+    overpricingRate?: number;
     x: number;
     y: number;
   } | null;
@@ -29,7 +30,7 @@ export function TreemapTooltip({ data }: TreemapTooltipProps) {
         >
           <div className="text-sm font-medium">{data.name}</div>
           <div className="text-xs text-muted-foreground">
-            {formatCurrency(data.value)}
+            {data.secondary ?? (data.value !== undefined ? formatCurrency(data.value) : '')}
           </div>
         </div>
       )}
@@ -41,7 +42,7 @@ export function TreemapTooltip({ data }: TreemapTooltipProps) {
         aria-atomic="true"
         className="sr-only"
       >
-        {data ? `${data.name}, ${formatCurrency(data.value)}, sobreprecio ${(data.overpricingRate * 100).toFixed(1)}%` : ''}
+        {data ? `${data.name}, ${data.secondary ?? (data.value !== undefined ? formatCurrency(data.value) : '')}${data.overpricingRate !== undefined ? `, sobreprecio ${(data.overpricingRate * 100).toFixed(1)}%` : ''}` : ''}
       </div>
     </>
   );

--- a/lib/number-to-roman.ts
+++ b/lib/number-to-roman.ts
@@ -1,0 +1,19 @@
+export function decimalToRoman(num: number): string {
+    if (num < 1 || num > 3999) return "Número fuera de rango";
+    
+    // Mapa de valores arábigos a romanos de mayor a menor
+    const map: { [key: string]: number } = {
+        M: 1000, CM: 900, D: 500, CD: 400,
+        C: 100, XC: 90, L: 50, XL: 40,
+        X: 10, IX: 9, V: 5, IV: 4, I: 1
+    };
+    
+    let resultado = "";
+    for (const key in map) {
+        while (num >= map[key]) {
+            resultado += key;
+            num -= map[key];
+        }
+    }
+    return resultado;
+}


### PR DESCRIPTION
Se refactoriza TreemapTooltip para hacerlo reutilizable y se integra en ChileMap para mostrar información en hover.
Ahora, al pasar el cursor sobre el mapa, se muestra:
- Nombre de la región
- Número de región (formato romano)
Se usa useRef y requestAnimationFrame para evitar re-renders innecesarios.

Esta muy bueno el proyecto.

